### PR TITLE
fix: CopyRightFooter import statement

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -7,7 +7,7 @@
 
 <script >
 import Vue from "vue";
-import CopyrightFooter from "./components/CopyrightFooter.vue";
+import CopyrightFooter from "./components/CopyRightFooter.vue";
 import "./dbr";
 import "./dcp";
 import { BarcodeScanner } from "dynamsoft-javascript-barcode";


### PR DESCRIPTION
The import statement for `CopyRightFooter` component was not correct and was fixed